### PR TITLE
Allow for customizing HttpClient creation

### DIFF
--- a/BreweryDB/BreweryDB.Tests/BreweryDB.Tests.csproj
+++ b/BreweryDB/BreweryDB.Tests/BreweryDB.Tests.csproj
@@ -28,11 +28,11 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Changes.cs" />
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BreweryDB.csproj">
-      <Project>{84d549c9-b9ca-4c37-8c99-2c12db8906b6}</Project>
+      <Project>{84D549C9-B9CA-4C37-8C99-2C12DB8906B6}</Project>
       <Name>BreweryDB</Name>
     </ProjectReference>
   </ItemGroup>

--- a/BreweryDB/BreweryDBClient.cs
+++ b/BreweryDB/BreweryDBClient.cs
@@ -1,6 +1,9 @@
 ﻿using BreweryDB.Interfaces;
 using BreweryDB.Models;
 using BreweryDB.Resources;
+using System.Net.Http;
+using System;
+using BreweryDB.Helpers;
 
 namespace BreweryDB
 {
@@ -9,9 +12,12 @@ namespace BreweryDB
         public static string ApplicationKey { get; private set; }
         public static readonly string BaseAddress = "https://api.brewerydb.com/v2/";
         
-        public BreweryDbClient(string key)
+        public BreweryDbClient(string key, Func<HttpClient> httpClientFactory = null)
         {
             ApplicationKey = key;
+
+            if (httpClientFactory != null)
+                JsonDownloader.HttpClientFactory = httpClientFactory;
 
             Beers = new BeerResource<Beer>(this);
             Breweries = new BreweryResource<Brewery>(this);

--- a/BreweryDB/Helpers/JsonDownloader.cs
+++ b/BreweryDB/Helpers/JsonDownloader.cs
@@ -12,9 +12,11 @@ namespace BreweryDB.Helpers
 {
     public static class JsonDownloader
     {
+        public static Func<HttpClient> HttpClientFactory { get; set; } = new Func<HttpClient>(() => new HttpClient());
+
         public static async Task<T> DownloadSerializedJsonDataAsync<T>(string url) where T : new()
         {
-            using (var httpClient = new HttpClient())
+            using (var httpClient = HttpClientFactory())
             {
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 var jsonData = string.Empty;


### PR DESCRIPTION
This change allows for customizing the creation of `HttpClient` in order to allow for using libraries like `ModernHttpClient`, or providing custom handlers of your own. I tried to find the least intrusive path to adding this injection point, but let me know if I missed something :smile: 
